### PR TITLE
SB-122 (feat) : 회원관리 요청에 대한 유효성 검증 기능 구현

### DIFF
--- a/warehouse/src/main/java/warehouse/common/customvalidation/CustomValidator.java
+++ b/warehouse/src/main/java/warehouse/common/customvalidation/CustomValidator.java
@@ -1,0 +1,38 @@
+package warehouse.common.customvalidation;
+
+import global.api.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomValidator implements Validator {
+
+    private final SpringValidatorAdapter validator;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return Api.class.equals(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (target instanceof Api) {
+            Api<?> api = (Api<?>) target;
+            Object body = api.getBody();
+            validator.validate(body, errors);
+
+            //TODO 예외 처리
+            if (errors.hasErrors()) {
+                throw new RuntimeException();
+            }
+        }
+    }
+}

--- a/warehouse/src/main/java/warehouse/domain/users/controller/UsersOpenApiController.java
+++ b/warehouse/src/main/java/warehouse/domain/users/controller/UsersOpenApiController.java
@@ -1,6 +1,7 @@
 package warehouse.domain.users.controller;
 
 import global.api.Api;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.tomcat.util.http.parser.Authorization;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,16 +25,18 @@ public class UsersOpenApiController {
 
     @PostMapping()
     public Api<UsersRegisteredResponse> register(
-        @RequestBody Api<UsersRegisterRequest> request
+        @RequestBody Api<@Valid UsersRegisterRequest> request
     ){
+        //TODO @Valid 검토 필요
         UsersRegisteredResponse response = usersBusiness.register(request.getBody());
         return Api.OK(response);
     }
 
     @PostMapping("/login")
     public Api<TokenResponse> login(
-        @RequestBody Api<UserLoginRequest> request
+        @RequestBody Api<@Valid UserLoginRequest> request
     ){
+        //TODO @Valid 검토 필요
         TokenResponse response = usersBusiness.login(request.getBody());
         return Api.OK(response);
     }

--- a/warehouse/src/main/java/warehouse/domain/users/controller/UsersOpenApiController.java
+++ b/warehouse/src/main/java/warehouse/domain/users/controller/UsersOpenApiController.java
@@ -4,11 +4,13 @@ import global.api.Api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.tomcat.util.http.parser.Authorization;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import warehouse.common.customvalidation.CustomValidator;
 import warehouse.domain.users.business.UsersBusiness;
 import warehouse.domain.users.controller.model.login.UserLoginRequest;
 import warehouse.domain.users.controller.model.register.UsersRegisterRequest;
@@ -22,21 +24,22 @@ import warehouse.domain.users.security.jwt.model.TokenResponse;
 public class UsersOpenApiController {
 
     private final UsersBusiness usersBusiness;
+    private final CustomValidator customValidator;
 
     @PostMapping()
     public Api<UsersRegisteredResponse> register(
-        @RequestBody Api<@Valid UsersRegisterRequest> request
-    ){
-        //TODO @Valid 검토 필요
+        @RequestBody @Valid Api<UsersRegisterRequest> request, Errors errors
+    ) {
+        customValidator.validate(request, errors);
         UsersRegisteredResponse response = usersBusiness.register(request.getBody());
         return Api.OK(response);
     }
 
     @PostMapping("/login")
     public Api<TokenResponse> login(
-        @RequestBody Api<@Valid UserLoginRequest> request
-    ){
-        //TODO @Valid 검토 필요
+        @RequestBody @Valid Api<UserLoginRequest> request, Errors errors
+    ) {
+        customValidator.validate(request, errors);
         TokenResponse response = usersBusiness.login(request.getBody());
         return Api.OK(response);
     }

--- a/warehouse/src/main/java/warehouse/domain/users/controller/model/login/UserLoginRequest.java
+++ b/warehouse/src/main/java/warehouse/domain/users/controller/model/login/UserLoginRequest.java
@@ -1,5 +1,6 @@
 package warehouse.domain.users.controller.model.login;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserLoginRequest {
 
+    @Pattern(regexp = "^[0-9a-zA-Z]{1,100}@[0-9a-zA-Z]+(\\.[0-9a-zA-Z]+)+$")
     private String email;
+
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[^a-zA-Z0-9])(?!.*[\\\\[\\\\]{}()<>#$%^&*_=|~`]).{8,100}$")
     private String password;
 
 }

--- a/warehouse/src/main/java/warehouse/domain/users/controller/model/register/UsersRegisterRequest.java
+++ b/warehouse/src/main/java/warehouse/domain/users/controller/model/register/UsersRegisterRequest.java
@@ -1,5 +1,9 @@
 package warehouse.domain.users.controller.model.register;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,12 +15,27 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UsersRegisterRequest {
 
+    @Pattern(regexp = "^[0-9a-zA-Z]{1,100}@[0-9a-zA-Z]+(\\.[0-9a-zA-Z]+)+$")
     private String email;
+
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[^a-zA-Z0-9])(?!.*[\\\\[\\\\]{}()<>#$%^&*_=|~`]).{8,100}$")
     private String password;
+
+    @Pattern(regexp = "^[가-힣]{1,50}$")
     private String name;
+
+    @NotBlank
+    @Size(max = 200)
     private String address;
+
+    @NotBlank
+    @Size(max = 200)
     private String detailAddress;
+
+    @NotNull
     private boolean basicAddress;
+
+    @Pattern(regexp = "^[0-9]{5}$")
     private int post;
 
 }


### PR DESCRIPTION
SB-122 (feat) : 회원관리 요청에 대한 유효성 검증 기능 구현

1. email 
    - ^[0-9a-zA-Z]{1,100} : 0-9, a-z, A-Z로 최소 1에서 최대100자까지 가능
    - @ : 사용자 이름과 도메인을 구분
    - [0-9a-zA-Z] : 도메인 부분도, 숫자, 소문자, 대문자 중 하나 이상의 문자로 구성
    - (\\.[0-9a-zA-Z]+)+
        1. \\. : 도메인과 하위 도메인을 . 으로 구분
        2. [0-9a-zA-Z] : 숫자, 소문자, 대문자 중 하나 이상의 문자로 구성
        3. + : 반복 수행 가능
        4. $ : 문자열의 끝

2. password
    - ^ : 문자열 시작
    - (?=.*[A-Z]) : 대문자가 최소 한 번 이상 포함
    - (?=.*[a-z]) : 소문자가 최소 한 번 이상 포함
    - (?=.*[^a-zA-Z0-9]) : 특수문자 한 번 이상 포함
    - (?!.*[\\\{}()<>#$%^&*_=|~])` : 프로그래밍 기호 제외
    - .{8,100} : 최소 8자리 이상, 최대 100자
    - $ : 문자열의 끝
1. name
    - 한글로 구성된 1 ~ 50 자리 문자열
2. address 
    - 최대 200자리 까지의 문자열
    - “”, null, “ “ 불가
3. detailAddress
    - 위와 동일
4. basicAddress
    - boolean에는 NotNull 사용
5. post
    - 0~9 까지의 문자열 허용
    - (int가 아닌 String 형식이어야 함)
    
    
--- 

Api<Request> 를 검증하기 위한 `CustomValidator` 구현 완료
