### PR TITLE
SB-225 (refactor) : GoodsService Logic Refactoring

### DIFF
--- a/warehouse/src/main/java/warehouse/domain/goods/service/GoodsService.java
+++ b/warehouse/src/main/java/warehouse/domain/goods/service/GoodsService.java
@@ -73,24 +73,19 @@ public class GoodsService {
             .orElseThrow(() -> new GoodsNotFoundException(GoodsErrorCode.GOODS_NOT_FOUND));
     }
 
-    public void checkStoredGoodsAndStatusWithThrowBy(Long receivingId, GoodsStatus status) {
-        List<GoodsEntity> goodsList = findAllBy(receivingId);
-        checkEmptyGoodsListWithThrow(goodsList);
-        checkGoodsStatusWithThrow(goodsList, status);
+    public void checkGoodsStatusWithThrow(Long goodsId, GoodsStatus status) {
+        GoodsEntity goodsEntity = this.getGoodsBy(goodsId);
+        checkGoodsStatusWithThrow(goodsEntity, status);
     }
 
-    public void checkStoredGoodsAndStatusWithThrowBy(List<Long> goodsIdList, GoodsStatus status) {
-        List<GoodsEntity> goodsList = getGoodsListBy(goodsIdList);
-        checkEmptyGoodsListWithThrow(goodsList);
-        checkGoodsStatusWithThrow(goodsList, status);
+    public void checkGoodsStatusWithThrow(List<Long> goodsIdList, GoodsStatus status) {
+        goodsIdList.forEach((goodsId) -> this.checkGoodsStatusWithThrow(goodsId, status));
     }
 
-    private void checkGoodsStatusWithThrow(List<GoodsEntity> goodsList, GoodsStatus status) {
-        goodsList.forEach(goodsEntity -> {
-            if (goodsEntity.getStatus() != status) {
-                throw new InvalidGoodsStatusException(GoodsErrorCode.INVALID_GOODS_STRATEGY);
-            }
-        });
+    private void checkGoodsStatusWithThrow(GoodsEntity goodsEntity, GoodsStatus status) {
+        if (goodsEntity.getStatus() != status) {
+            throw new InvalidGoodsStatusException(GoodsErrorCode.INVALID_GOODS_STRATEGY);
+        }
     }
 
     private void checkEmptyGoodsListWithThrow(List<GoodsEntity> goodsList) {
@@ -100,8 +95,6 @@ public class GoodsService {
     }
 
     public void setGoodsStatusBy(Long goodsId, GoodsStatus status) {
-        // GoodsStatus 가 STORAGE 가 아닌 경우 예외
-        checkStoredGoodsAndStatusWithThrowBy(goodsId, GoodsStatus.STORAGE);
         GoodsEntity goodsEntity = getGoodsBy(goodsId);
         setGoodsStatusBy(status, goodsEntity);
     }
@@ -147,10 +140,10 @@ public class GoodsService {
         return goodsEntityList;
     }
 
-    public void setShippingId(ShippingRequest request,Long shippingId) {
+    public void setShippingId(ShippingRequest request, Long shippingId) {
         // GoodsStatus 를 SHIPPING_ING 으로 변경
         request.getGoodsIdList().forEach(goodsId -> {
-            setGoodsStatusBy(goodsId,GoodsStatus.SHIPPING_ING);
+            setGoodsStatusBy(goodsId, GoodsStatus.SHIPPING_ING);
         });
 
         List<GoodsEntity> goodsEntityList = getGoodsListBy(request.getGoodsIdList());
@@ -160,5 +153,4 @@ public class GoodsService {
             goodsRepository.save(goodsEntity);
         });
     }
-
 }

--- a/warehouse/src/main/java/warehouse/domain/shipping/business/ShippingBusiness.java
+++ b/warehouse/src/main/java/warehouse/domain/shipping/business/ShippingBusiness.java
@@ -36,7 +36,7 @@ public class ShippingBusiness {
     @Transactional
     public MessageResponse shippingRequest(ShippingRequest request, String email) {
         // 상품이 STORAGE 인지 확인
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(request.getGoodsIdList(),
+        goodsService.checkGoodsStatusWithThrow(request.getGoodsIdList(),
             GoodsStatus.STORAGE);
         Long userId = getUserWithThrow(email).getId();
         ShippingEntity shippingEntity = shippingConverter.toEntity(request, userId);

--- a/warehouse/src/main/java/warehouse/domain/takeback/business/TakeBackBusiness.java
+++ b/warehouse/src/main/java/warehouse/domain/takeback/business/TakeBackBusiness.java
@@ -38,7 +38,11 @@ public class TakeBackBusiness {
 
     public TakeBackResponse takeBackRequest(Long receivingId, String email) {
 
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(receivingId, GoodsStatus.RECEIVING);
+        List<GoodsEntity> goodsEntityList = goodsService.findAllByReceivingIdWithThrow(receivingId);
+
+        List<Long> goodsIdList = goodsEntityList.stream().map((goodsEntity) -> goodsEntity.getId()).toList();
+
+        goodsService.checkGoodsStatusWithThrow(goodsIdList, GoodsStatus.RECEIVING);
 
         receivingService.initReceivingStatus(receivingId);
 
@@ -47,8 +51,6 @@ public class TakeBackBusiness {
         TakeBackEntity takeBackEntity = takeBackConverter.toEntity(userEntity.getId());
 
         TakeBackEntity newTakeBackEntity = takeBackService.takeBackRequest(takeBackEntity);
-
-        List<GoodsEntity> goodsEntityList = goodsService.findAllByReceivingIdWithThrow(receivingId);
 
         goodsService.setTakeBackIdAndStatus(goodsEntityList, newTakeBackEntity.getId(),
             GoodsStatus.TAKE_BACK_ING);
@@ -62,7 +64,7 @@ public class TakeBackBusiness {
 
     public TakeBackResponse takeBackRequest(List<Long> goodsIdList, String email) {
 
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(goodsIdList, GoodsStatus.RECEIVING);
+        goodsService.checkGoodsStatusWithThrow(goodsIdList, GoodsStatus.RECEIVING);
 
         UserEntity userEntity = usersService.getUserWithThrow(email);
 

--- a/warehouse/src/main/java/warehouse/domain/usedgoods/business/UsedGoodsBusiness.java
+++ b/warehouse/src/main/java/warehouse/domain/usedgoods/business/UsedGoodsBusiness.java
@@ -38,7 +38,7 @@ public class UsedGoodsBusiness {
     public TransformUsedGoodsResponse transformUsedGoods(Long goodsId) {
 
         // GoodsStatus 를 USED 로 변경
-        setGoodsStatusUsedBy(goodsId,GoodsStatus.USED);
+        setGoodsStatusUsedBy(goodsId, GoodsStatus.USED);
 
         GoodsEntity goodsEntity = getGoodsBy(goodsId);
 
@@ -51,9 +51,9 @@ public class UsedGoodsBusiness {
 
     public TransformUsedGoodsResponse cancelUsedGoodsRequest(Long goodsId) {
 
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(goodsId, GoodsStatus.USED);
+        goodsService.checkGoodsStatusWithThrow(goodsId, GoodsStatus.USED);
 
-        setGoodsStatusUsedBy(goodsId,GoodsStatus.STORAGE);
+        setGoodsStatusUsedBy(goodsId, GoodsStatus.STORAGE);
 
         GoodsEntity goodsEntity = getGoodsBy(goodsId);
 
@@ -62,9 +62,9 @@ public class UsedGoodsBusiness {
 
     public List<TransformUsedGoodsResponse> cancelUsedGoodsRequest(List<Long> goodsIdList) {
 
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(goodsIdList, GoodsStatus.USED);
+        goodsService.checkGoodsStatusWithThrow(goodsIdList, GoodsStatus.USED);
 
-        goodsIdList.forEach(goodsId -> setGoodsStatusUsedBy(goodsId,GoodsStatus.STORAGE));
+        goodsIdList.forEach(goodsId -> setGoodsStatusUsedBy(goodsId, GoodsStatus.STORAGE));
 
         List<GoodsEntity> goodsEntityList = goodsService.getGoodsListBy(goodsIdList);
 
@@ -73,11 +73,11 @@ public class UsedGoodsBusiness {
 
     public UsedGoodsPostResponse post(UsedGoodsPostRequest request, String email) {
 
-        goodsService.checkStoredGoodsAndStatusWithThrowBy(request.getGoodsId(), GoodsStatus.USED);
+        goodsService.checkGoodsStatusWithThrow(request.getGoodsId(), GoodsStatus.USED);
 
         Long userId = usersService.getUserWithThrow(email).getId();
 
-        UsedGoodsEntity usedGoodsEntity = usedGoodsConverter.toEntity(request,userId);
+        UsedGoodsEntity usedGoodsEntity = usedGoodsConverter.toEntity(request, userId);
 
         UsedGoodsEntity savedEntity = usedGoodsService.post(usedGoodsEntity);
 
@@ -90,7 +90,7 @@ public class UsedGoodsBusiness {
         return usedGoodsConverter.toResponse(savedEntity, goodsResponse);
     }
 
-    private void setGoodsStatusUsedBy(Long goodId,GoodsStatus status) {
+    private void setGoodsStatusUsedBy(Long goodId, GoodsStatus status) {
         goodsService.setGoodsStatusBy(goodId, status);
     }
 


### PR DESCRIPTION
# SB-225 (refactor) : GoodsService Logic Refactoring

1. GoodsService
    - setGoodsStatusBy() 책임 분리
    - checkStoredGoodsAndStatusWithThrowBy -> checkGoodsStatusWithThrow 메서드명 변경
    - checkGoodsStatusWithThrow 파라미터 receivingId -> goodsId 로 변경하여 일관성있게 변경하였습니다.
2. ShippingBusiness, UsedGoodsBusiness
    - checkStoredGoodsAndStatusWithThrowBy() -> checkGoodsStatusWithThrow() 메서드명 변경
3. TakeBackBusiness
    - receivingId 를 파라미터로 넘기지 않고 goodsId 를 파라미터로 전달

---


checkGoodsStatusWithThrow(Long goodsId, GoodsStatus status) 호출 시 goods의 존재 유무는 getGoodsBy() 메서드에서 처리합니다.

setGoodsStatusBy() 는 오직 GoodsStatus 만 변경하는 책임을 가지도록 변경하였습니다.