### PR TITLE
SB-236 (feat) : 반품 요청서 상태 조회 기능 개발

### DIFF
--- a/warehouse/src/main/java/warehouse/domain/takeback/business/TakeBackBusiness.java
+++ b/warehouse/src/main/java/warehouse/domain/takeback/business/TakeBackBusiness.java
@@ -8,20 +8,17 @@ import global.annotation.Business;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import warehouse.common.utils.ImageUtils;
 import warehouse.domain.goods.controller.model.GoodsResponse;
 import warehouse.domain.goods.converter.GoodsConverter;
 import warehouse.domain.goods.service.GoodsService;
 import warehouse.domain.image.controller.model.ImageListResponse;
 import warehouse.domain.image.converter.ImageConverter;
-import warehouse.domain.image.service.ImageService;
-import warehouse.domain.receiving.converter.receiving.ReceivingConverter;
 import warehouse.domain.receiving.service.ReceivingService;
 import warehouse.domain.takeback.controller.model.TakeBackListResponse;
 import warehouse.domain.takeback.controller.model.TakeBackResponse;
+import warehouse.domain.takeback.controller.model.TakeBackStatusResponse;
 import warehouse.domain.takeback.converter.TakeBackConverter;
 import warehouse.domain.takeback.service.TakeBackService;
-import warehouse.domain.users.converter.UsersConverter;
 import warehouse.domain.users.service.UsersService;
 
 @Slf4j
@@ -112,5 +109,10 @@ public class TakeBackBusiness {
         }).toList();
 
         return takeBackConverter.toListResponse(takeBackResponseList);
+    }
+
+    public TakeBackStatusResponse getCurrentStatusBy(Long takeBackId) {
+        TakeBackEntity takeBackEntity = takeBackService.getTakeBackById(takeBackId);
+        return takeBackConverter.toCurrentStatusResponse(takeBackEntity);
     }
 }

--- a/warehouse/src/main/java/warehouse/domain/takeback/controller/TakeBackController.java
+++ b/warehouse/src/main/java/warehouse/domain/takeback/controller/TakeBackController.java
@@ -16,6 +16,7 @@ import warehouse.domain.receiving.controller.model.receiving.ReceivingResponse;
 import warehouse.domain.takeback.business.TakeBackBusiness;
 import warehouse.domain.takeback.controller.model.TakeBackListResponse;
 import warehouse.domain.takeback.controller.model.TakeBackResponse;
+import warehouse.domain.takeback.controller.model.TakeBackStatusResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,6 +52,13 @@ public class TakeBackController {
         @AuthenticationPrincipal User user
     ){
         TakeBackListResponse response = takeBackBusiness.getTakeBackListBy(user.getUsername());
+        return Api.OK(response);
+    }
+
+    @GetMapping("/process/{takeBackId}")
+    @Operation(summary = "[출고 상태 조회하기]")
+    public Api<TakeBackStatusResponse> getCurrentStatusBy(@PathVariable Long takeBackId) {
+        TakeBackStatusResponse response = takeBackBusiness.getCurrentStatusBy(takeBackId);
         return Api.OK(response);
     }
 

--- a/warehouse/src/main/java/warehouse/domain/takeback/controller/model/TakeBackStatusResponse.java
+++ b/warehouse/src/main/java/warehouse/domain/takeback/controller/model/TakeBackStatusResponse.java
@@ -1,0 +1,21 @@
+package warehouse.domain.takeback.controller.model;
+
+import db.domain.takeback.enums.TakeBackStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TakeBackStatusResponse {
+
+    private Long takeBackId;
+    private long total;
+    private TakeBackStatus status;
+    private int current;
+    private String description;
+
+}

--- a/warehouse/src/main/java/warehouse/domain/takeback/converter/TakeBackConverter.java
+++ b/warehouse/src/main/java/warehouse/domain/takeback/converter/TakeBackConverter.java
@@ -4,10 +4,12 @@ import db.domain.takeback.TakeBackEntity;
 import db.domain.takeback.enums.TakeBackStatus;
 import global.annotation.Converter;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import warehouse.domain.goods.controller.model.GoodsResponse;
 import warehouse.domain.takeback.controller.model.TakeBackListResponse;
 import warehouse.domain.takeback.controller.model.TakeBackResponse;
+import warehouse.domain.takeback.controller.model.TakeBackStatusResponse;
 
 @Converter
 public class TakeBackConverter {
@@ -44,6 +46,16 @@ public class TakeBackConverter {
     public TakeBackListResponse toListResponse(List<TakeBackResponse> takeBackResponseList) {
         return TakeBackListResponse.builder()
             .takeBackResponseList(takeBackResponseList)
+            .build();
+    }
+
+    public TakeBackStatusResponse toCurrentStatusResponse(TakeBackEntity takeBackEntity) {
+        return TakeBackStatusResponse.builder()
+            .takeBackId(takeBackEntity.getId())
+            .total(Arrays.stream(TakeBackStatus.values()).count())
+            .status(takeBackEntity.getStatus())
+            .description(takeBackEntity.getStatus().getDescription())
+            .current(takeBackEntity.getStatus().getCurrent())
             .build();
     }
 }


### PR DESCRIPTION
# SB-236 (feat) : 반품 요청서 상태 조회 기능 개발

## API
- `GET /api/takeback/process/{takeBakeId}` 로 상태 조회 가능

## 응답 형식
```
{
    "result": {
        "resultCode": 200,
        "resultMessage": "성공",
        "resultDescription": "성공"
    },
    "body": {
        "takeBackId": 1,
        "total": 4,
        "status": "TAKE_BACK_REGISTERING",
        "current": 1,
        "description": "반품 접수가 완료되었습니다."
    }
}
```


---
1. TakeBackStatusResponse
2. TakeBackApiController
3. TakeBackConverter
4. TakeBackBusiness