### PR TITLE
SB-284 (feat) : GoodsResponse 에 GoodsStatus 추가

### DIFF
--- a/warehouse/src/main/java/warehouse/domain/goods/controller/model/GoodsResponse.java
+++ b/warehouse/src/main/java/warehouse/domain/goods/controller/model/GoodsResponse.java
@@ -1,6 +1,7 @@
 package warehouse.domain.goods.controller.model;
 
 import db.domain.goods.enums.GoodsCategory;
+import db.domain.goods.enums.GoodsStatus;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,8 @@ public class GoodsResponse {
     private String name;
 
     private GoodsCategory category;
+
+    private GoodsStatus status;
 
     private int quantity;
 

--- a/warehouse/src/main/java/warehouse/domain/goods/converter/GoodsConverter.java
+++ b/warehouse/src/main/java/warehouse/domain/goods/converter/GoodsConverter.java
@@ -30,6 +30,7 @@ public class GoodsConverter {
             .basicImages(imageListResponse.getBasicImageListResponse())
             .faultImages(imageListResponse.getFaultImageListResponse())
             .category(goodsEntity.getCategory())
+            .status(goodsEntity.getStatus())
             .quantity(goodsEntity.getQuantity())
             .build();
     }


### PR DESCRIPTION
# SB-284 (feat) : GoodsResponse 에 GoodsStatus 추가

Client 요청에 따른 GoodsStatus 필드 추가
1. GoodsResponse
2. GoodsConverter

아래와 같이 `goods` 에 `status` 항목이 추가됩니다
```
{
  "result": {
    "resultCode": 0,
    "resultMessage": "string",
    "resultDescription": "string"
  },
  "body": {
    "takeBackResponseList": [
      {
        "id": 0,
        "status": "TAKE_BACK_REGISTERING",
        "takeBackRequestAt": "2024-08-23T06:52:26.694Z",
        "goods": [
          {
            "id": 0,
            "name": "string",
            "category": "SMALL_FURNITURE",
            "quantity": 0,
            "status": "RECEIVING", // 추가!!!!!
            "basicImages": [
              {
                "id": 0,
                "serverName": "string",
                "originalName": "string",
                "imageUrl": "string",
                "caption": "string",
                "kind": "BASIC",
                "goodsId": 0
              }
            ],
.
.
.
.
.
.

```