### PR TITLE
SB-339 (refactor) : 채팅 시스템 리팩토링

### DIFF
--- a/warehouse/src/main/java/warehouse/common/config/stomphandler/StompHandler.java
+++ b/warehouse/src/main/java/warehouse/common/config/stomphandler/StompHandler.java
@@ -1,0 +1,44 @@
+package warehouse.common.config.stomphandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import warehouse.domain.users.security.jwt.service.TokenService;
+import warehouse.domain.users.security.service.AuthorizationService;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class StompHandler implements ChannelInterceptor {
+
+    private final TokenService tokenService;
+    private final AuthorizationService authorizationService;
+
+    // WebSocket 을 통해 들어온 요청이 처리 되기 전 실행
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        // WebSocket 연결 시 헤더의 JWT Token 검증
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+            String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
+            String token = authorizationHeader.replace("Bearer ", ""); // "Bearer " 부분 제거
+            Long userId = tokenService.validationToken(token); // 토큰에서 사용자 ID 추출
+
+            UserDetails userDetails = authorizationService.loadUserByUsername(userId.toString());
+            Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null,
+                userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        return message;
+    }
+}

--- a/warehouse/src/main/java/warehouse/common/config/websocket/WebSocketConfig.java
+++ b/warehouse/src/main/java/warehouse/common/config/websocket/WebSocketConfig.java
@@ -2,16 +2,19 @@ package warehouse.common.config.websocket;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import warehouse.common.config.stomphandler.StompHandler;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -21,7 +24,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/chatting").setAllowedOrigins("*");
-            //.withSockJS();
+        registry.addEndpoint("/chatting")
+            .setAllowedOrigins("*");
+//            .withSockJS();
     }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
+
 }

--- a/warehouse/src/main/java/warehouse/domain/chat/business/ChatBusiness.java
+++ b/warehouse/src/main/java/warehouse/domain/chat/business/ChatBusiness.java
@@ -19,6 +19,7 @@ import warehouse.domain.chat.controller.model.response.MessageResponse;
 import warehouse.domain.chat.converter.ChatConverter;
 import warehouse.domain.chat.service.ChatService;
 import warehouse.domain.usedgoods.service.UsedGoodsService;
+import warehouse.domain.users.security.jwt.service.TokenService;
 import warehouse.domain.users.security.service.UsersService;
 
 @Business
@@ -29,6 +30,7 @@ public class ChatBusiness {
     private final ChatService chatService;
     private final UsedGoodsService usedGoodsService;
     private final UsersService usersService;
+    private final TokenService tokenService;
     private final ChatConverter chatConverter;
 
 
@@ -81,9 +83,10 @@ public class ChatBusiness {
      * 2. chatRoomId & userId 로 채팅방 접근 권한 체크
      * 3. 채팅 메시지 전송
      */
-    public void sendChatMessage(ChatMessageRequest message, String email) {
+    public void sendChatMessage(ChatMessageRequest message, String token) {
 
-        Long userId = usersService.getUserWithThrow(email).getId();
+        // 'Bearer ' 제거
+        Long userId = tokenService.validationToken(token.substring(7));
 
         ChatRoomEntity chatRoomEntity = chatService.getChatRoomBy(message.getChatRoomId());
 

--- a/warehouse/src/main/java/warehouse/domain/chat/controller/ChatApiController.java
+++ b/warehouse/src/main/java/warehouse/domain/chat/controller/ChatApiController.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,11 +56,11 @@ public class ChatApiController {
         return Api.OK(response);
     }
 
-    @PostMapping("/message")
-    @Operation(summary = "[message 전송]", description = "/pub/chat")
-    public void sendMessage(@RequestBody ChatMessageRequest message, @AuthenticationPrincipal User user) {
+    @MessageMapping("/message")
+    @Operation(summary = "[message 전송]", description = "/pub")
+    public void sendMessage(@RequestBody ChatMessageRequest message, @Header("Authorization") String token) {
         log.info(message.toString());
-        chatBusiness.sendChatMessage(message, user.getUsername());
+        chatBusiness.sendChatMessage(message, token);
     }
 
     @GetMapping("/buy") // 구매 채팅방 조회


### PR DESCRIPTION
# SB-339 (refactor) : 채팅 시스템 리팩토링

- StompHandler 구현
    - `WebSocket` 연결이 성립된 후의 메시지 교환 과정에서는 `HTTP` 요청과는 다르게 `Spring Security Filter` 를 거치지 않음.
    - 따라서, `채널 인터셉터(Channel Interceptors)`를 사용하여 `WebSocket` 메시지에 대한 보안 로직 및 추가 작업 진행.
- `WebSocketConfig Interceptor(StompHandler) Bean` 등록
- `ChatApiController Mapping` 변경
    - `@PostMapping -> @MessageMapping`

## Sub/Pub
- Sub : `/sub/chat/{chatRoomId}`
- Pub : `/pub/message`
    - content : `{"message" : "String", "chatRoomId" : 0}`

## To Reviewer
- `StompHandler` 에서 `SecurityContextHolder` 를 사용하여 `Controller` 에서 사용자 정보를 참조하려 했으나, `Could not read JSON: Cannot construct instance of 'org.springframework.security.core.userdetails.User'` 오류가 발생합니다.
- 임시로 `@Header()` 로 대체함

### 문제 코드
```
    @MessageMapping("/message")
    @Operation(summary = "[message 전송]", description = "/pub")
    public void sendMessage(@RequestBody ChatMessageRequest message, @AuthenticationPrincipal User user) {
        log.info(message.toString());
        chatBusiness.sendChatMessage(message, user.getUsername());
    }
```
### 예외
```
org.springframework.messaging.converter.MessageConversionException: Could not read JSON: Cannot construct instance of `org.springframework.security.core.userdetails.User` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (byte[])"{"message" : "subscriber테스트입니다", "chatRoomId" : 3969826777361042339}"; line: 1, column: 2]
	at org.springframework.messaging.converter.MappingJackson2MessageConverter.convertFromInternal(MappingJackson2MessageConverter.java:256) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.converter.AbstractMessageConverter.fromMessage(AbstractMessageConverter.java:183) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.converter.CompositeMessageConverter.fromMessage(CompositeMessageConverter.java:70) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver.resolveArgument(PayloadMethodArgumentResolver.java:144) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:118) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:147) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:115) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMatch(AbstractMethodMessageHandler.java:567) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:529) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:93) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessageInternal(AbstractMethodMessageHandler.java:522) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(AbstractMethodMessageHandler.java:457) ~[spring-messaging-6.1.6.jar:6.1.6]
	at org.springframework.messaging.support.ExecutorSubscribableChannel$SendTask.run(ExecutorSubscribableChannel.java:152) ~[spring-messaging-6.1.6.jar:6.1.6]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.springframework.security.core.userdetails.User` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (byte[])"{"message" : "subscriber테스트입니다", "chatRoomId" : 3969826777361042339}"; line: 1, column: 2]
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1915) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1360) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1434) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:352) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4825) ~[jackson-databind-2.15.4.jar:2.15.4]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3866) ~[jackson-databind-2.15.4.jar:2.15.4]
	at org.springframework.messaging.converter.MappingJackson2MessageConverter.convertFromInternal(MappingJackson2MessageConverter.java:242) ~[spring-messaging-6.1.6.jar:6.1.6]
	... 15 common frames omitted
```
